### PR TITLE
Expose value to string for gateway

### DIFF
--- a/caPutLogApp/caPutLogTask.c
+++ b/caPutLogApp/caPutLogTask.c
@@ -84,7 +84,6 @@
 static void caPutLogTask(void *arg);
 static void log_msg(const VALUE *pold_value, const LOGDATA *pLogData,
     int burst, const VALUE *pmin, const VALUE *pmax, int config);
-static int  val_to_string(char *pbuf, size_t buflen, const VALUE *pval, short type);
 static void val_min(VALUE *pres, const VALUE *pa, const VALUE *pb, short type);
 static void val_max(VALUE *pres, const VALUE *pa, const VALUE *pb, short type);
 static int  val_equal(const VALUE *pa, const VALUE *pb, short type);
@@ -327,7 +326,7 @@ static void log_msg(const VALUE *pold_value, const LOGDATA *pLogData,
     if (len >= space) { do_log(msg, space-1, YES); return; }
 
     /* new value */
-    len += val_to_string(msg+len, space-len,
+    len += caPutLogVALUEToString(msg+len, space-len,
         &pLogData->new_value.value, pLogData->type);
     if (len >= space) { do_log(msg, space-1, YES); return; }
 
@@ -335,20 +334,20 @@ static void log_msg(const VALUE *pold_value, const LOGDATA *pLogData,
     if (len >= space) { do_log(msg, space-1, YES); return; }
 
     /* old value */
-    len += val_to_string(msg+len, space-len, pold_value, pLogData->type);
+    len += caPutLogVALUEToString(msg+len, space-len, pold_value, pLogData->type);
     if (len >= space) { do_log(msg, space-1, YES); return; }
 
     if (burst && isDbrNumeric(pLogData->type)) {
         /* min value */
         len += epicsSnprintf(msg+len, space-len, " min=");
         if (len >= space) { do_log(msg, space-1, YES); return; }
-        len += val_to_string(msg+len, space-len, pmin, pLogData->type);
+        len += caPutLogVALUEToString(msg+len, space-len, pmin, pLogData->type);
         if (len >= space) { do_log(msg, space-1, YES); return; }
 
         /* max value */
         len += epicsSnprintf(msg+len, space-len, " max=");
         if (len >= space) { do_log(msg, space-1, YES); return; }
-        len += val_to_string(msg+len, space-len, pmax, pLogData->type);
+        len += caPutLogVALUEToString(msg+len, space-len, pmax, pLogData->type);
         if (len >= space) { do_log(msg, space-1, YES); return; }
     }
     do_log(msg, len, NO);
@@ -513,9 +512,9 @@ static void val_assign(VALUE *dst, const VALUE *src, short type)
 }
 
 /*
- * val_to_string(): convert VALUE to string
+ * caPutLogVALUEToString(): convert VALUE to string
  */
-static int val_to_string(char *pbuf, size_t buflen, const VALUE *pval, short type)
+static int caPutLogVALUEToString(char *pbuf, size_t buflen, const VALUE *pval, short type)
 {
     switch (type) {
     case DBR_CHAR:
@@ -562,8 +561,8 @@ static void val_dump(LOGDATA *pdata)
         strcpy(oldbuf,"(conv fail)");
         strcpy(newbuf,"(conv fail)");
         strcpy(timebuf,"(strftime fail)");
-        val_to_string(oldbuf,sizeof(oldbuf),&pdata->old_value,pdata->type);
-        val_to_string(newbuf,sizeof(newbuf),&pdata->new_value.value,pdata->type);
+        caPutLogVALUEToString(oldbuf,sizeof(oldbuf),&pdata->old_value,pdata->type);
+        caPutLogVALUEToString(newbuf,sizeof(newbuf),&pdata->new_value.value,pdata->type);
         epicsTimeToStrftime(timebuf,sizeof(timebuf),"%Y-%m-%dT%H:%M:%S",&pdata->new_value.time);
         printf("userid = %s\n", pdata->userid);
         printf("hostid = %s\n", pdata->hostid);

--- a/caPutLogApp/caPutLogTask.c
+++ b/caPutLogApp/caPutLogTask.c
@@ -514,7 +514,7 @@ static void val_assign(VALUE *dst, const VALUE *src, short type)
 /*
  * caPutLogVALUEToString(): convert VALUE to string
  */
-static int caPutLogVALUEToString(char *pbuf, size_t buflen, const VALUE *pval, short type)
+int caPutLogVALUEToString(char *pbuf, size_t buflen, const VALUE *pval, short type)
 {
     switch (type) {
     case DBR_CHAR:

--- a/caPutLogApp/caPutLogTask.h
+++ b/caPutLogApp/caPutLogTask.h
@@ -44,7 +44,7 @@ typedef struct {
 epicsShareFunc int caPutLogTaskStart(int config);
 epicsShareFunc void caPutLogTaskStop(void);
 epicsShareFunc void caPutLogTaskSend(LOGDATA *plogData);
-epicsShareFunc int epicsShareAPI caPutLogVALUEToString(char *pbuf, size_t buflen, const VALUE *pval, short type);
+epicsShareFunc int caPutLogVALUEToString(char *pbuf, size_t buflen, const VALUE *pval, short type);
 
 #ifdef __cplusplus
 }

--- a/caPutLogApp/caPutLogTask.h
+++ b/caPutLogApp/caPutLogTask.h
@@ -44,6 +44,7 @@ typedef struct {
 epicsShareFunc int caPutLogTaskStart(int config);
 epicsShareFunc void caPutLogTaskStop(void);
 epicsShareFunc void caPutLogTaskSend(LOGDATA *plogData);
+epicsShareFunc int epicsShareAPI caPutLogVALUEToString(char *pbuf, size_t buflen, const VALUE *pval, short type);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Expose val_to_string() as caPutLogVALUEToString() - this is used by the EPICS gateway 