### PR TITLE
Dirk's improvements

### DIFF
--- a/caPutLogApp/Makefile
+++ b/caPutLogApp/Makefile
@@ -8,6 +8,9 @@ LIBRARY_IOC = caPutLog
 USR_CPPFLAGS += -DUSE_TYPED_RSET
 USR_CPPFLAGS_WIN32 += -DNOMINMAX
 
+# set time stamp format:
+#USR_CPPFLAGS+=-DDEFAULT_TIME_FMT="%Y-%m-%d %H:%M:%S.%6f"
+
 caPutLog_SRCS += caPutLogTask.c
 caPutLog_SRCS += caPutLogAs.c
 caPutLog_SRCS += caPutLogClient.c

--- a/caPutLogApp/caPutJsonLogTask.h
+++ b/caPutLogApp/caPutJsonLogTask.h
@@ -148,7 +148,6 @@ private:
     static CaPutJsonLogTask *instance;
 
     // Logger configuration
-    const char * address;
     int config; // To modify or read this value only epicsAtomic methods should be used
 
     // Interthread communication
@@ -158,8 +157,13 @@ private:
     epicsThreadId threadId;
     int taskStopper; // To modify or read this value only epicsAtomic methods should be used
 
-    //Logging to a server
-    logClientId caPutJsonLogClient;
+    //Logging to a list of servers
+    struct clientItem {
+        logClientId caPutJsonLogClient;
+        struct clientItem *next;
+        char address[1];
+    } *clients;
+    epicsMutex clientsMutex;
 
     // Logging to a PV
     DBADDR caPutJsonLogPV;

--- a/caPutLogApp/caPutLog.c
+++ b/caPutLogApp/caPutLog.c
@@ -45,9 +45,6 @@ void caPutLogShow (int level)
     if (level < 0) level = 0;
     if (level > 2) level = 2;
     caPutLogTaskShow();
-#if 0
-    caPutLogAsShow(level);
-#endif
     caPutLogClientShow(level);
 }
 

--- a/caPutLogApp/caPutLog.c
+++ b/caPutLogApp/caPutLog.c
@@ -44,6 +44,7 @@ void caPutLogShow (int level)
 {
     if (level < 0) level = 0;
     if (level > 2) level = 2;
+    caPutLogTaskShow();
 #if 0
     caPutLogAsShow(level);
 #endif
@@ -55,9 +56,10 @@ void caPutLogShow (int level)
  */
 int caPutLogReconf (int config)
 {
-#if 0
-    caPutLogTaskReconf(config);
-#endif
+    if (config < 0)
+        caPutLogTaskStop();
+    else
+        caPutLogTaskStart(config);
     caPutLogClientFlush();
     return caPutLogSuccess;
 }

--- a/caPutLogApp/caPutLog.dbd
+++ b/caPutLogApp/caPutLog.dbd
@@ -1,1 +1,2 @@
+variable(caPutLogDebug,int)
 registrar(caPutLogRegister)

--- a/caPutLogApp/caPutLog.h
+++ b/caPutLogApp/caPutLog.h
@@ -20,6 +20,7 @@ extern "C" {
 epicsShareFunc int caPutLogInit (const char *addr_str, int config);
 epicsShareFunc int caPutLogReconf (int config);
 epicsShareFunc void caPutLogShow (int level);
+epicsShareFunc void caPutLogSetTimeFmt (const char *format);
 
 #ifdef __cplusplus
 }

--- a/caPutLogApp/caPutLogClient.c
+++ b/caPutLogApp/caPutLogClient.c
@@ -28,6 +28,8 @@
 #include <logClient.h>
 #include <epicsString.h>
 #include <epicsStdio.h>
+#include <epicsMutex.h>
+#include <cantProceed.h>
 
 #define epicsExportSharedSymbols
 #include "caPutLog.h"
@@ -43,21 +45,24 @@
 
 LOCAL READONLY ENV_PARAM EPICS_CA_PUT_LOG_ADDR = {"EPICS_CA_PUT_LOG_ADDR", ""};
 
-LOCAL struct clientlist {
+LOCAL struct clientItem {
     logClientId caPutLogClient;
-    struct clientlist *next;
+    struct clientItem *next;
     char addr[1];
 } *caPutLogClients = NULL;
+static epicsMutexId caPutLogClientsMutex;
 
 /*
  *  caPutLogClientFlush ()
  */
 void caPutLogClientFlush ()
 {
-    struct clientlist* c;
+    struct clientItem* c;
+    epicsMutexMustLock(caPutLogClientsMutex);
     for (c = caPutLogClients; c; c = c->next) {
         logClientFlush (c->caPutLogClient);
     }
+    epicsMutexUnlock(caPutLogClientsMutex);
 }
 
 /*
@@ -65,10 +70,12 @@ void caPutLogClientFlush ()
  */
 void caPutLogClientShow (unsigned level)
 {
-    struct clientlist* c;
+    struct clientItem* c;
+    epicsMutexMustLock(caPutLogClientsMutex);
     for (c = caPutLogClients; c; c = c->next) {
         logClientShow (c->caPutLogClient, level);
     }
+    epicsMutexUnlock(caPutLogClientsMutex);
 }
 
 /*
@@ -79,12 +86,14 @@ int caPutLogClientInit (const char *addr_str)
     int status;
     struct sockaddr_in saddr;
     unsigned short default_port = 7011;
-    struct clientlist** pclient;
+    struct clientItem** pclient;
     char *clientaddr;
     char *saveptr;
     char *addr_str_copy1;
     char *addr_str_copy2;
 
+    if (!caPutLogClientsMutex)
+        caPutLogClientsMutex = epicsMutexMustCreate();
     if (!addr_str || !addr_str[0]) {
         if (caPutLogClients) return caPutLogSuccess;
         addr_str = envGetConfigParamPtr(&EPICS_CA_PUT_LOG_ADDR);
@@ -96,6 +105,7 @@ int caPutLogClientInit (const char *addr_str)
 
     addr_str_copy2 = addr_str_copy1 = epicsStrDup(addr_str);
 
+    epicsMutexMustLock(caPutLogClientsMutex);
     while(1) {
         clientaddr = strtok_r(addr_str_copy1, " \t\n\r", &saveptr);
         if (!clientaddr) break;
@@ -115,11 +125,7 @@ int caPutLogClientInit (const char *addr_str)
             continue;
         }
 
-        *pclient = malloc(sizeof(struct clientlist)+strlen(clientaddr));
-        if (!*pclient) {
-            fprintf (stderr, "caPutLog: out of memory\n");
-            return caPutLogError;
-        }
+        *pclient = callocMustSucceed(1,sizeof(struct clientItem)+strlen(clientaddr),"caPutLog");
         strcpy((*pclient)->addr, clientaddr);
 
         (*pclient)->caPutLogClient = logClientCreate (saddr.sin_addr, ntohs(saddr.sin_port));
@@ -132,6 +138,7 @@ int caPutLogClientInit (const char *addr_str)
 
         (*pclient)->next = NULL;
     }
+    epicsMutexUnlock(caPutLogClientsMutex);
     free(addr_str_copy2);
     return caPutLogClients ? caPutLogSuccess : caPutLogError;
 }
@@ -141,8 +148,10 @@ int caPutLogClientInit (const char *addr_str)
  */
 void caPutLogClientSend (const char *message)
 {
-    struct clientlist* c;
+    struct clientItem* c;
+    epicsMutexMustLock(caPutLogClientsMutex);
     for (c = caPutLogClients; c; c = c->next) {
         logClientSend (c->caPutLogClient, message);
     }
+    epicsMutexUnlock(caPutLogClientsMutex);
 }

--- a/caPutLogApp/caPutLogClient.c
+++ b/caPutLogApp/caPutLogClient.c
@@ -26,6 +26,8 @@
 #include <envDefs.h>
 #include <errlog.h>
 #include <logClient.h>
+#include <epicsString.h>
+#include <epicsStdio.h>
 
 #define epicsExportSharedSymbols
 #include "caPutLog.h"
@@ -35,17 +37,26 @@
 #define LOCAL static
 #endif
 
+#ifdef _WIN32
+#define strtok_r strtok_s
+#endif
+
 LOCAL READONLY ENV_PARAM EPICS_CA_PUT_LOG_ADDR = {"EPICS_CA_PUT_LOG_ADDR", ""};
 
-LOCAL logClientId caPutLogClient;
+LOCAL struct clientlist {
+    logClientId caPutLogClient;
+    struct clientlist *next;
+    char addr[1];
+} *caPutLogClients = NULL;
 
 /*
  *  caPutLogClientFlush ()
  */
 void caPutLogClientFlush ()
 {
-    if (caPutLogClient!=NULL) {
-        logClientFlush (caPutLogClient);
+    struct clientlist* c;
+    for (c = caPutLogClients; c; c = c->next) {
+        logClientFlush (c->caPutLogClient);
     }
 }
 
@@ -54,8 +65,9 @@ void caPutLogClientFlush ()
  */
 void caPutLogClientShow (unsigned level)
 {
-    if (caPutLogClient!=NULL) {
-        logClientShow (caPutLogClient, level);
+    struct clientlist* c;
+    for (c = caPutLogClients; c; c = c->next) {
+        logClientShow (c->caPutLogClient, level);
     }
 }
 
@@ -66,13 +78,15 @@ int caPutLogClientInit (const char *addr_str)
 {
     int status;
     struct sockaddr_in saddr;
-    long default_port = 7011;
-
-    if (caPutLogClient!=NULL) {
-        return caPutLogSuccess;
-    }
+    unsigned short default_port = 7011;
+    struct clientlist** pclient;
+    char *clientaddr;
+    char *saveptr;
+    char *addr_str_copy1;
+    char *addr_str_copy2;
 
     if (!addr_str || !addr_str[0]) {
+        if (caPutLogClients) return caPutLogSuccess;
         addr_str = envGetConfigParamPtr(&EPICS_CA_PUT_LOG_ADDR);
     }
     if (addr_str == NULL) {
@@ -80,20 +94,46 @@ int caPutLogClientInit (const char *addr_str)
         return caPutLogError;
     }
 
-    status = aToIPAddr (addr_str, default_port, &saddr);
-    if (status<0) {
-        fprintf (stderr, "caPutLog: bad address or host name\n");
-        return caPutLogError;
-    }
+    addr_str_copy2 = addr_str_copy1 = epicsStrDup(addr_str);
 
-    caPutLogClient = logClientCreate (saddr.sin_addr, ntohs(saddr.sin_port));
+    while(1) {
+        clientaddr = strtok_r(addr_str_copy1, " \t\n\r", &saveptr);
+        if (!clientaddr) break;
+        addr_str_copy1 = NULL;
 
-    if (!caPutLogClient) {
-        return caPutLogError;
+        for (pclient = &caPutLogClients; *pclient; pclient = &(*pclient)->next) {
+            if (strcmp(clientaddr, (*pclient)->addr) == 0) {
+                fprintf (stderr, "caPutLog: address %s already configured\n", clientaddr);
+                break;
+            }
+        }
+        if (*pclient) continue;
+
+        status = aToIPAddr (clientaddr, default_port, &saddr);
+        if (status<0) {
+            fprintf (stderr, "caPutLog: bad address or host name %s\n", clientaddr);
+            continue;
+        }
+
+        *pclient = malloc(sizeof(struct clientlist)+strlen(clientaddr));
+        if (!*pclient) {
+            fprintf (stderr, "caPutLog: out of memory\n");
+            return caPutLogError;
+        }
+        strcpy((*pclient)->addr, clientaddr);
+
+        (*pclient)->caPutLogClient = logClientCreate (saddr.sin_addr, ntohs(saddr.sin_port));
+        if (!(*pclient)->caPutLogClient) {
+            fprintf (stderr, "caPutLog: cannot create logClient %s\n", clientaddr);
+            free(*pclient);
+            *pclient = NULL;
+            continue;
+        }
+
+        (*pclient)->next = NULL;
     }
-    else {
-        return caPutLogSuccess;
-    }
+    free(addr_str_copy2);
+    return caPutLogClients ? caPutLogSuccess : caPutLogError;
 }
 
 /*
@@ -101,7 +141,8 @@ int caPutLogClientInit (const char *addr_str)
  */
 void caPutLogClientSend (const char *message)
 {
-    if (caPutLogClient) {
-        logClientSend (caPutLogClient, message);
+    struct clientlist* c;
+    for (c = caPutLogClients; c; c = c->next) {
+        logClientSend (c->caPutLogClient, message);
     }
 }

--- a/caPutLogApp/caPutLogShellCommands.c
+++ b/caPutLogApp/caPutLogShellCommands.c
@@ -36,6 +36,16 @@ static void caPutLogShowCall(const iocshArgBuf *args)
     caPutLogShow(args[0].ival);
 }
 
+static const iocshArg caPutLogSetTimeFmtArg0 = {"format", iocshArgPersistentString};
+static const iocshArg *const caPutLogSetTimeFmtArgs[] = {
+    &caPutLogSetTimeFmtArg0
+};
+static const iocshFuncDef caPutLogSetTimeFmtDef = {"caPutLogSetTimeFmt", 1, caPutLogSetTimeFmtArgs};
+static void caPutLogSetTimeFmtCall(const iocshArgBuf *args)
+{
+    caPutLogSetTimeFmt(args[0].sval);
+}
+
 static void caPutLogRegister(void)
 {
     static int done = FALSE;
@@ -45,5 +55,6 @@ static void caPutLogRegister(void)
     iocshRegister(&caPutLogInitDef,caPutLogInitCall);
     iocshRegister(&caPutLogReconfDef,caPutLogReconfCall);
     iocshRegister(&caPutLogShowDef,caPutLogShowCall);
+    iocshRegister(&caPutLogSetTimeFmtDef,caPutLogSetTimeFmtCall);
 }
 epicsExportRegistrar(caPutLogRegister);

--- a/caPutLogApp/caPutLogTask.c
+++ b/caPutLogApp/caPutLogTask.c
@@ -82,6 +82,15 @@
 
 #define MAX_BUF_SIZE    256     /* Length of log string */
 
+#ifndef DEFAULT_TIME_FMT
+#define DEFAULT_TIME_FMT %d-%b-%y %H:%M:%S
+#endif
+#define STR2(x) #x
+#define STR(x) STR2(x)
+#define DEFAULT_TIME_FMT_STR STR(DEFAULT_TIME_FMT)
+
+static const char *timeFormat = DEFAULT_TIME_FMT_STR;
+
 static void caPutLogTask(void *arg);
 static void log_msg(const VALUE *pold_value, const LOGDATA *pLogData,
     int burst, const VALUE *pmin, const VALUE *pmax, int config);
@@ -181,6 +190,12 @@ void caPutLogTaskSend(LOGDATA *plogData)
         }
     }
     caPutLogDataFree(plogData);
+}
+
+void caPutLogSetTimeFmt (const char *format)
+{
+    if (format)
+        timeFormat = format;
 }
 
 static void caPutLogTask(void *arg)
@@ -324,9 +339,9 @@ static void log_msg(const VALUE *pold_value, const LOGDATA *pLogData,
     }
 
     /* first comes the time */
-    len = epicsTimeToStrftime(msg, space, "%d-%b-%y %H:%M:%S",
+    len = epicsTimeToStrftime(msg, space, timeFormat,
         &pLogData->new_value.time);
-    /* this should always succeed (18 chars, last time i counted */
+    /* this should always succeed */
     assert(len);
 
     /* host, user, pv_name */

--- a/caPutLogApp/caPutLogTask.c
+++ b/caPutLogApp/caPutLogTask.c
@@ -167,10 +167,17 @@ void caPutLogTaskStop(void)
 
 void caPutLogTaskSend(LOGDATA *plogData)
 {
+    static int overflow = 0;
     if (caPutLogQ) {
         if (!epicsMessageQueueTrySend(caPutLogQ, &plogData, MSG_SIZE))
+        {
+            overflow = 0;
             return;
-        errlogSevPrintf(errlogMinor, "caPutLog: message queue overflow\n");
+        }
+        if (!overflow) {
+            errlogSevPrintf(errlogMinor, "caPutLog: message queue overflow\n");
+            overflow = 1;
+        }
     }
     caPutLogDataFree(plogData);
 }

--- a/caPutLogApp/caPutLogTask.c
+++ b/caPutLogApp/caPutLogTask.c
@@ -47,6 +47,7 @@
 #include <epicsMessageQueue.h>
 #include <epicsThread.h>
 
+#include <epicsString.h>
 #include <dbFldTypes.h>
 #include <epicsTypes.h>
 #include <dbDefs.h>
@@ -527,8 +528,8 @@ static int val_to_string(char *pbuf, size_t buflen, const VALUE *pval, short typ
     switch (type) {
     case DBR_CHAR:
        /* CHAR and UCHAR are typically used as SHORTSHORT,
-	* so avoid mounting NULL-bytes into the string
-	*/
+        * so avoid mounting NULL-bytes into the string
+        */
         return epicsSnprintf(pbuf, buflen, "%d", (int)pval->v_uint8);
     case DBR_UCHAR:
         return epicsSnprintf(pbuf, buflen, "%d", (int)pval->v_uint8);
@@ -552,7 +553,13 @@ static int val_to_string(char *pbuf, size_t buflen, const VALUE *pval, short typ
         return epicsSnprintf(pbuf, buflen, "%llu", pval->v_uint64);
 #endif
     default:
-        return epicsSnprintf(pbuf, buflen, "%s", pval->v_string);
+        if (buflen < 3) return 0;
+        pbuf[0] = '"';
+        epicsStrnEscapedFromRaw(pbuf+1, buflen-2, pval->v_string, strlen(pval->v_string));
+        buflen = strlen(pbuf);
+        pbuf[buflen++] = '"';
+        pbuf[buflen] = 0;
+        return buflen;
     }
 }
 

--- a/caPutLogApp/caPutLogTask.h
+++ b/caPutLogApp/caPutLogTask.h
@@ -69,6 +69,7 @@ typedef struct {
 epicsShareFunc int caPutLogTaskStart(int config);
 epicsShareFunc void caPutLogTaskStop(void);
 epicsShareFunc void caPutLogTaskSend(LOGDATA *plogData);
+epicsShareFunc void caPutLogTaskShow(void);
 
 #ifdef __cplusplus
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -173,6 +173,7 @@ in rapid succession; in this case only the original and the final value as
 well as the minimum and maximum value are logged. This filtering can be
 disabled by specifying the ``caPutLogAllNoFilter`` (``2``) configuration option.
 
+From release 4 on, string values are quoted and special characters are escaped.
 
 Json Log Format
 +++++++++++++++

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -138,7 +138,7 @@ Other shell commands for logger are:
    ``caPutLogInit`` / ``caPutJsonLogInit``.
 
 ``caPutLogShow level`` / ``caPutJsonLogShow level``
-   Show information about a running caPutLog,
+   Show information about a running caPutLog, including config parameter.
    level is the usual interest level (0, 1, or 2).
 
 Server

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,6 +100,9 @@ or for JSON output format::
 
 where ``host`` (mandatory argument) is the IP address or host name of the log
 server and ``port`` is optional (the default is 7011).
+To log to multiple hosts, either call the funtion with a space separated list like
+``"host1[:port] host2[:port]"`` or call the function multiple times with different
+hosts.
 
 The environment variable ``EPICS_CA_PUT_LOG_ADDR`` / ``EPICS_CA_PUT_JSON_LOG_ADDR``
 is used if the first parameter to ``caPutLogInit`` / ``caPutJsonLogInit`` is ``NULL``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -263,6 +263,12 @@ too long for the record it will be truncated.
 .. note::  As of EPICS base 7.0.1 ``lso``/``lsi`` records will be truncate a message at
     40 character. As workaround add ``.$`` or ``.VAL$`` to a PV name.
 
+Debugging
++++++++++
+
+To switch on debug messages, set ``var caPutLogDebug,1``.
+
+
 Acknowledgments
 ----------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -174,6 +174,9 @@ well as the minimum and maximum value are logged. This filtering can be
 disabled by specifying the ``caPutLogAllNoFilter`` (``2``) configuration option.
 
 From release 4 on, string values are quoted and special characters are escaped.
+The default date/time format ``%d-%b-%y %H:%M:%S`` may be changed at compile time
+with the macro DEFAULT_TIME_FMT and/or modified at run time using the shell function
+``caPutLogSetTimeFmt "<date_time_format>"``.
 
 Json Log Format
 +++++++++++++++

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -7,6 +7,7 @@ Changes since R3-7
 -------------------------
 
   * add new JSON log format
+  * quote and escape strings in non-JSON logs
 
 
 .. _R3-5:

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -8,6 +8,7 @@ Changes since R3-7
 
   * add new JSON log format
   * quote and escape strings in non-JSON logs
+  * allow to change time format
 
 
 .. _R3-5:

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -10,6 +10,7 @@ Changes since R3-7
   * quote and escape strings in non-JSON logs
   * allow to change time format
   * allow multiple receivers
+  * fix caPutLogReconf which was non-functional
 
 
 .. _R3-5:

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -11,6 +11,7 @@ Changes since R3-7
   * allow to change time format
   * allow multiple receivers
   * fix caPutLogReconf which was non-functional
+  * allow to switch on debug messages at run time
 
 
 .. _R3-5:

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -9,6 +9,7 @@ Changes since R3-7
   * add new JSON log format
   * quote and escape strings in non-JSON logs
   * allow to change time format
+  * allow multiple receivers
 
 
 .. _R3-5:


### PR DESCRIPTION
Some cumulative improvements made at PSI over the last years:

New features:
- Allow to send logs to multiple receivers
- Do not flood terminal with buffer overflow messages
- Allow changing log mode at run-time (actually made `caPutLogReconf` functional ) and show current log mode in `caPutLogShow`.
- Allow to switch on debug messages at run time

Changes in message formatting:
- Quote and escape string values
- Allow to change time stamp format at compile time and/or run time.