### PR TITLE
Add counters for total puts and burst

### DIFF
--- a/caPutLogApp/caPutJsonLogTask.cpp
+++ b/caPutLogApp/caPutJsonLogTask.cpp
@@ -593,7 +593,7 @@ caPutJsonLogStatus CaPutJsonLogTask::buildJsonMsg(const VALUE *pold_value, const
                         strlen(reinterpret_cast<char *>(interBuffer))));
 
         // Add burst count
-        const unsigned char str_burst[] = "burst_count";
+        const unsigned char str_burst[] = "burst";
         CALL_YAJL_FUNCTION_AND_CHECK_STATUS(status, yajl_gen_string(handle, str_burst,
                                 strlen(reinterpret_cast<const char *>(str_burst))));
         CALL_YAJL_FUNCTION_AND_CHECK_STATUS(status, yajl_gen_integer(handle, burst));

--- a/caPutLogApp/caPutJsonLogTask.cpp
+++ b/caPutLogApp/caPutJsonLogTask.cpp
@@ -272,7 +272,8 @@ caPutJsonLogStatus CaPutJsonLogTask::configurePvLogging()
 void CaPutJsonLogTask::caPutJsonLogTask(void *arg)
 {
 
-    bool sent = false, burst = false;
+    bool sent = false;
+    int burst = 0;
     LOGDATA *pcurrent, *pnext;
     VALUE old_value, max_value, min_value;
     VALUE *pold=&old_value, *pmax=&max_value, *pmin=&min_value;
@@ -301,7 +302,7 @@ void CaPutJsonLogTask::caPutJsonLogTask(void *arg)
                 buildJsonMsg(pold, pcurrent, burst, pmin, pmax);
                 std::memcpy(pold, &pcurrent->new_value.value, sizeof(VALUE));
                 sent = true;
-                burst = false;
+                burst = 0;
             }
         }
 
@@ -326,12 +327,12 @@ void CaPutJsonLogTask::caPutJsonLogTask(void *arg)
                 std::memcpy(pmin, &pcurrent->new_value.value, sizeof(VALUE));
 
                 sent = false;
-                burst = false;
+                burst = 0;
             }
             // Multiple puts within timeout
             else {
                 if (isDbrNumeric(pcurrent->type) && pcurrent->new_size == 1) {
-                    burst = true;
+                    burst++;
                     calculateMax(pmax, &pcurrent->new_value.value, pmax, pcurrent->type);
                     calculateMin(pmin, &pcurrent->new_value.value, pmin, pcurrent->type);
                 }
@@ -356,7 +357,7 @@ void CaPutJsonLogTask::caPutJsonLogTask(void *arg)
             std::memcpy(pmin, &pcurrent->new_value.value, sizeof(VALUE));
 
             sent = false;
-            burst = false;
+            burst = 0;
         }
     }
     epics::atomic::set(this->taskStopper,  false);
@@ -383,7 +384,7 @@ void CaPutJsonLogTask::addPutToQueue(LOGDATA * plogData)
     }
 
 caPutJsonLogStatus CaPutJsonLogTask::buildJsonMsg(const VALUE *pold_value, const LOGDATA *pLogData,
-                                bool burst, const VALUE *pmin, const VALUE *pmax)
+                                int burst, const VALUE *pmin, const VALUE *pmax)
 {
     // Intermediate message build buffer
     // The longest message for the buffer can occur in the lso/lsi records which
@@ -583,6 +584,12 @@ caPutJsonLogStatus CaPutJsonLogTask::buildJsonMsg(const VALUE *pold_value, const
         CALL_YAJL_FUNCTION_AND_CHECK_STATUS(status, yajl_gen_number(handle,
                         reinterpret_cast<const char *>(interBuffer),
                         strlen(reinterpret_cast<char *>(interBuffer))));
+
+        // Add burst count
+        const unsigned char str_burst[] = "burst_count";
+        CALL_YAJL_FUNCTION_AND_CHECK_STATUS(status, yajl_gen_string(handle, str_burst,
+                                strlen(reinterpret_cast<const char *>(str_burst))));
+        CALL_YAJL_FUNCTION_AND_CHECK_STATUS(status, yajl_gen_integer(handle, burst));
     }
 
     /* Close root map */

--- a/caPutLogApp/caPutJsonLogTask.h
+++ b/caPutLogApp/caPutJsonLogTask.h
@@ -55,7 +55,7 @@ enum specialValues {
  * \code{.txt}
  * <iocLogPrefix>{"date": "<dd>-<mm>-<yyyy>"","time":"<hh>:<mm>:<ss>","host":"<client hostname>","user":"<client username>","pv":"<pv name>","new":<new value>,"old":"<old value>"}\n
  * \endcode
- * Burst puts add extra JSON properties (supported only for numberic scalar puts):
+ * Burst puts add extra JSON properties (supported only for numeric scalar puts):
  *  - "min": Which is a minimum value inside the burst period
  *  - "max": Represents maximum value inside the burst of puts
  * Array puts add following JSON properties:
@@ -183,13 +183,13 @@ private:
      *
      * @param pold_value Pointer to a ::VALUE structure holding an old PV value.
      * @param pLogData Pointer to a ::LOGDATA structure holding new value and other meta databa about the put.
-     * @param burst Boolean value. It determinate if put was a burst of values.
+     * @param burst Integer value. Indicates the number of burst of values, if any.
      * @param pmin Pointer to a ::VALUE structure holding an min value if burst is true.
      * @param pmax Pointer to a ::VALUE structure holding an max value if burst is true.
      * @return int Status code.
      */
     caPutJsonLogStatus buildJsonMsg(const VALUE *pold_value, const LOGDATA *pLogData,
-            bool burst, const VALUE *pmin, const VALUE *pmax);
+            int burst, const VALUE *pmin, const VALUE *pmax);
 
     /**
      * @brief Configure logging to a server.

--- a/caPutLogApp/caPutJsonLogTask.h
+++ b/caPutLogApp/caPutJsonLogTask.h
@@ -144,7 +144,7 @@ public:
 
 private:
 
-    // Singelton instance of this class.
+    // Singleton instance of this class.
     static CaPutJsonLogTask *instance;
 
     // Logger configuration

--- a/caPutLogApp/caPutJsonLogTask.h
+++ b/caPutLogApp/caPutJsonLogTask.h
@@ -169,6 +169,8 @@ private:
     DBADDR caPutJsonLogPV;
     DBADDR *pCaPutJsonLogPV;
 
+    // Total count of logged puts
+    int caPutTotalCount; // To modify or read this value only epicsAtomic methods should be used
 
     // Class methods (Do not allow public constructors - class is designed as singleton)
     CaPutJsonLogTask();

--- a/caPutLogApp/caPutLogTask.c
+++ b/caPutLogApp/caPutLogTask.c
@@ -276,9 +276,10 @@ static void caPutLogTask(void *arg)
             }
 
             /* current and next are same pv */
-
             caPutLogDataFree(pcurrent);
             pcurrent = pnext;
+
+            epicsAtomicIncrIntT(&caPutLogTotalCount);
 
             if (sent) {
                 /* Set new initial max & min values */
@@ -291,7 +292,6 @@ static void caPutLogTask(void *arg)
             else {              /* Next put of multiple puts */
                 if (isDbrNumeric(pcurrent->type)) {
                     burst++;
-                    epicsAtomicIncrIntT(&caPutLogTotalCount);
                     val_max(pmax, &pcurrent->new_value.value, pmax, pcurrent->type);
                     val_min(pmin, &pcurrent->new_value.value, pmin, pcurrent->type);
                 }
@@ -311,6 +311,8 @@ static void caPutLogTask(void *arg)
 
             caPutLogDataFree(pcurrent);
             pcurrent = pnext;
+
+            epicsAtomicIncrIntT(&caPutLogTotalCount);
 
             /* Set new old_value */
             val_assign(pold, &pcurrent->old_value, pcurrent->type);

--- a/caPutLogApp/caPutLogTask.c
+++ b/caPutLogApp/caPutLogTask.c
@@ -55,6 +55,7 @@
 #include <errlog.h>
 #include <asLib.h>
 #include <epicsAssert.h>
+#include <epicsAtomic.h>
 
 #include <epicsExport.h>
 #include "caPutLog.h"
@@ -111,6 +112,8 @@ static volatile int caPutLogConfig;
 
 int caPutLogDebug = 0;
 epicsExportAddress(int, caPutLogDebug);
+
+int caPutLogTotalCount = 0;
 
 #define MAX_MSGS 1000                   /* The length of queue (in messages) */
 #define MSG_SIZE sizeof(LOGDATA*)       /* We store only pointers */
@@ -184,6 +187,7 @@ void caPutLogTaskShow(void)
         default: state = "invalid";
     }
     printf("caPutLog mode: %d = %s\n", caPutLogConfig, state);
+    printf("caPutLog Total Count: %d\n", epicsAtomicGetIntT(&caPutLogTotalCount));
 }
 
 void caPutLogTaskStop(void)
@@ -285,6 +289,7 @@ static void caPutLogTask(void *arg)
             else {              /* Next put of multiple puts */
                 if (isDbrNumeric(pcurrent->type)) {
                     burst = TRUE;
+                    epicsAtomicIncrIntT(&caPutLogTotalCount);
                     val_max(pmax, &pcurrent->new_value.value, pmax, pcurrent->type);
                     val_min(pmin, &pcurrent->new_value.value, pmin, pcurrent->type);
                 }

--- a/caPutLogApp/caPutLogTask.c
+++ b/caPutLogApp/caPutLogTask.c
@@ -408,7 +408,7 @@ static void log_msg(const VALUE *pold_value, const LOGDATA *pLogData,
         if (len >= space) { do_log(msg, space-1, YES); return; }
 
         /* burst count */
-        len += epicsSnprintf(msg+len, space-len, " burst_count=%d", burst);
+        len += epicsSnprintf(msg+len, space-len, " burst=%d", burst);
         if (len >= space) { do_log(msg, space-1, YES); return; }
     }
     do_log(msg, len, NO);

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -202,7 +202,7 @@ record.field name, and <change> is either::
 
 or::
 
-   new=<value> old=<value> min=<value> max=<value> burst_count=<value>
+   new=<value> old=<value> min=<value> max=<value> burst=<value>
 
 The latter format means that several puts for the same PV were received in quick
 succession; in this case only the original and final values of the burst as well
@@ -230,7 +230,7 @@ It looks like this::
         "new":<new value>,["new-size":<new array size>,]
         "old":<new value>[,"old-size":<old array size>]
         [,"min":<minimum value>][,"max":<maximum value>]
-        [,"burst_count":<burst count>]}<LF>
+        [,"burst":<burst count>]}<LF>
 
 The JSON properties are:
 
@@ -269,7 +269,7 @@ The JSON properties are:
     * **max** value is included only if the burst filtering was applied and
       gives the maximum value of the puts received within the burst period.
 
-    * **burst_count** number of filtered puts in the burst period.
+    * **burst** number of filtered puts in the burst period.
 
 The JSON implementation of the logger added support for arrays and long string
 fields. As these values can get very large, there is a limit to how long the
@@ -303,7 +303,7 @@ Burst of scalar values::
         "pv":"ao",
         "new":8,"old":77.5,
         "min":7.5,"max":870.5,
-        "burst_count"=10}<LF>
+        "burst"=10}<LF>
 
 String value::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -201,12 +201,13 @@ record.field name, and <change> is either::
 
 or::
 
-   new=<value> old=<value> min=<value> max=<value>
+   new=<value> old=<value> min=<value> max=<value> burst_count=<value>
 
 The latter format means that several puts for the same PV were received in quick
 succession; in this case only the original and final values of the burst as well
-as the minimum and maximum values seen are logged. This burst filtering can be
-disabled by selecting the ``caPutLogAllNoFilter`` (``2``) configuration value.
+as the minimum and maximum values seen are logged. The number of successive puts
+filtered is also logged. This burst filtering can be disabled by selecting the
+``caPutLogAllNoFilter`` (``2``) configuration value.
 
 From release 4.0 on, string values are placed inside quotes, and special
 characters within the string are escaped. The default date/time format
@@ -227,7 +228,8 @@ It looks like this::
         "pv":"<pv name>",
         "new":<new value>,["new-size":<new array size>,]
         "old":<new value>[,"old-size":<old array size>]
-        [,"min":<minimum value>][,"max":<maximum value>]}<LF>
+        [,"min":<minimum value>][,"max":<maximum value>]
+        [,"burst_count":<burst count>]}<LF>
 
 The JSON properties are:
 
@@ -266,6 +268,8 @@ The JSON properties are:
     * **max** value is included only if the burst filtering was applied and
       gives the maximum value of the puts received within the burst period.
 
+    * **burst_count** number of filtered puts in the burst period.
+
 The JSON implementation of the logger added support for arrays and long string
 fields. As these values can get very large, there is a limit to how long the
 **new value** and **old value** properties can be. Each value can use up to 400
@@ -297,7 +301,8 @@ Burst of scalar values::
         "host":"devWs","user":"devman",
         "pv":"ao",
         "new":8,"old":77.5,
-        "min":7.5,"max":870.5}<LF>
+        "min":7.5,"max":870.5,
+        "burst_count"=10}<LF>
 
 String value::
 
@@ -400,4 +405,3 @@ If you have any problems with this module, send me (`Ben Franksen`_) a mail.
 .. _R3-3: releasenotes.rst#r3-3-changes-since-r3-2
 .. _R3-2: releasenotes.rst#r3-2-changes-since-r3-1
 .. _R3-1: releasenotes.rst#r3-1-changes-since-r3-0
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -161,7 +161,8 @@ Other shell commands for controlling the logger are:
 ``caPutLogShow level`` / ``caPutJsonLogShow level``
 
    Show information about an active logger, including its current ``config``
-   setting. ``level`` is the usual interest level (0, 1, or 2).
+   setting and total number of logged puts. ``level`` is the usual interest
+   level (0, 1, or 2).
 
 
 Set up a Log Server


### PR DESCRIPTION
The total counter is being displayed in all  information levels. My reasoning for this is that this is a basic information that would be useful to get alongside the server information on the base information level.

Implements #11 