### PR TITLE
Add configurable burst filter time

### DIFF
--- a/caPutLogApp/caPutJsonLogShellCommands.cpp
+++ b/caPutLogApp/caPutJsonLogShellCommands.cpp
@@ -23,40 +23,44 @@ extern "C"
     extern int caPutLogJsonMsgQueueSize;
 
     /* Initalisation */
-    int caPutJsonLogInit(const char * address, caPutJsonLogConfig config){
+    int caPutJsonLogInit(const char * address, caPutJsonLogConfig config, double timeout){
         CaPutJsonLogTask *logger =  CaPutJsonLogTask::getInstance();
-        if (logger != NULL) return logger->initialize(address, config);
+        if (logger != NULL) return logger->initialize(address, config, timeout);
         else return -1;
     }
 
     static const iocshArg caPutJsonLogInitArg0 = {"address", iocshArgString};
     static const iocshArg caPutJsonLogInitArg1 = {"config", iocshArgInt};
+    static const iocshArg caPutJsonLogInitArg2 = {"burst timeout", iocshArgDouble};
     static const iocshArg *const caPutJsonLogInitArgs[] = {
         &caPutJsonLogInitArg0,
-        &caPutJsonLogInitArg1
+        &caPutJsonLogInitArg1,
+        &caPutJsonLogInitArg2
     };
-    static const iocshFuncDef caPutjsonLogInitDef = {"caPutJsonLogInit", 2, caPutJsonLogInitArgs};
+    static const iocshFuncDef caPutjsonLogInitDef = {"caPutJsonLogInit", 3, caPutJsonLogInitArgs};
     static void caPutJsonLogInitCall(const iocshArgBuf *args)
     {
-        caPutJsonLogInit(args[0].sval, static_cast<caPutJsonLogConfig>(args[1].ival));
+        caPutJsonLogInit(args[0].sval, static_cast<caPutJsonLogConfig>(args[1].ival), args[2].dval);
     }
 
 
     /* Reconfigure */
-    int caPutJsonLogReconf(caPutJsonLogConfig config){
+    int caPutJsonLogReconf(caPutJsonLogConfig config, double timeout){
         CaPutJsonLogTask *logger =  CaPutJsonLogTask::getInstance();
-        if (logger != NULL)  return logger->reconfigure(config);
+        if (logger != NULL)  return logger->reconfigure(config, timeout);
         else return -1;
     }
 
     static const iocshArg caPutJsonLogReconfArg0 = {"config", iocshArgInt};
+    static const iocshArg caPutJsonLogReconfArg1 = {"burst timeout", iocshArgDouble};
     static const iocshArg *const caPutJsonLogReconfArgs[] = {
-        &caPutJsonLogReconfArg0
+        &caPutJsonLogReconfArg0,
+        &caPutJsonLogReconfArg1
     };
     static const iocshFuncDef caPutJsonLogReconfDef = {"caPutJsonLogReconf", 1, caPutJsonLogReconfArgs};
     static void caPutJsonLogReconfCall(const iocshArgBuf *args)
     {
-        caPutJsonLogReconf(static_cast<caPutJsonLogConfig>(args[0].ival));
+        caPutJsonLogReconf(static_cast<caPutJsonLogConfig>(args[0].ival), args[1].dval);
     }
 
     /* Report */
@@ -76,6 +80,22 @@ extern "C"
         caPutJsonLogShow(args[0].ival);
     }
 
+    /* Change burst filter timeout */
+    int caPutJsonLogSetBurstTimeout(double timeout){
+        CaPutJsonLogTask *logger =  CaPutJsonLogTask::getInstance();
+        if (logger != NULL)  return logger->setBurstTimeout(timeout);
+        else return -1;
+    }
+
+    static const iocshArg caPutJsonLogSetBurstTimeoutArg0 = {"burst timeout", iocshArgDouble};
+    static const iocshArg *const caPutJsonLogSetBurstTimeoutArgs[] = {
+        &caPutJsonLogSetBurstTimeoutArg0
+    };
+    static const iocshFuncDef caPutJsonLogSetBurstTimeoutDef = {"caPutJsonLogSetBurstTimeout", 1, caPutJsonLogSetBurstTimeoutArgs};
+    static void caPutJsonLogSetBurstTimeoutCall(const iocshArgBuf *args)
+    {
+        caPutJsonLogSetBurstTimeout(args[0].dval);
+    }
 
     /* Register IOCsh commands */
     static void caPutJsonLogRegister(void)
@@ -87,6 +107,7 @@ extern "C"
         iocshRegister(&caPutjsonLogInitDef,caPutJsonLogInitCall);
         iocshRegister(&caPutJsonLogReconfDef,caPutJsonLogReconfCall);
         iocshRegister(&caPutJsonLogShowDef,caPutJsonLogShowCall);
+        iocshRegister(&caPutJsonLogSetBurstTimeoutDef,caPutJsonLogSetBurstTimeoutCall);
     }
     epicsExportRegistrar(caPutJsonLogRegister);
 

--- a/caPutLogApp/caPutJsonLogTask.cpp
+++ b/caPutLogApp/caPutJsonLogTask.cpp
@@ -86,7 +86,7 @@ CaPutJsonLogTask::~CaPutJsonLogTask()
     }
 }
 
-caPutJsonLogStatus CaPutJsonLogTask::reconfigure(caPutJsonLogConfig config)
+caPutJsonLogStatus CaPutJsonLogTask::reconfigure(caPutJsonLogConfig config, double timeout)
 {
     if ((config < caPutJsonLogNone)
         || (config > caPutJsonLogAllNoFilter)) {
@@ -95,6 +95,9 @@ caPutJsonLogStatus CaPutJsonLogTask::reconfigure(caPutJsonLogConfig config)
     } else {
         epics::atomic::set(this->config, config);
     }
+
+    this->setBurstTimeout(timeout);
+
     return caPutJsonLogSuccess;
 }
 
@@ -115,12 +118,12 @@ caPutJsonLogStatus CaPutJsonLogTask::report(int level)
     }
 }
 
-caPutJsonLogStatus CaPutJsonLogTask::initialize(const char* addresslist, caPutJsonLogConfig config)
+caPutJsonLogStatus CaPutJsonLogTask::initialize(const char* addresslist, caPutJsonLogConfig config, double timeout)
 {
     caPutJsonLogStatus status;
 
     // Store passed configuration parameters
-    this->reconfigure(config);
+    this->reconfigure(config, timeout);
 
     // Check if user enabled the logger
     if (config == caPutJsonLogNone) {
@@ -242,6 +245,16 @@ caPutJsonLogStatus CaPutJsonLogTask::configureServerLogging(const char* address)
     return caPutJsonLogSuccess;
 }
 
+caPutJsonLogStatus CaPutJsonLogTask::setBurstTimeout( double timeout )
+{
+    if (timeout > 0.0) {
+        this->burstTimeout = timeout;
+    } else {
+        this->burstTimeout = default_burst_timeout;
+    }
+    return caPutJsonLogSuccess;
+}
+
 caPutJsonLogStatus CaPutJsonLogTask::configurePvLogging()
 {
     char *caPutJsonLogPVEnv;
@@ -292,7 +305,7 @@ void CaPutJsonLogTask::caPutJsonLogTask(void *arg)
         int msgSize;
 
         // Receive new put with timeout
-        msgSize = this->caPutJsonLogQ.receive(&pnext, sizeof(LOGDATA *), 5.0);
+        msgSize = this->caPutJsonLogQ.receive(&pnext, sizeof(LOGDATA *), this->burstTimeout);
 
         /* Timeout */
         if (msgSize == -1) {

--- a/caPutLogApp/caPutJsonLogTask.h
+++ b/caPutLogApp/caPutJsonLogTask.h
@@ -78,6 +78,9 @@ public:
     // Default port to be used if not specified by the user
     static const int default_port = 7011;
 
+    // Default burst filter timeout if not specified by the user
+    const double default_burst_timeout = 5.0;
+
     /**
      * @brief Get the singleton Instance object.
      *
@@ -90,10 +93,11 @@ public:
      *
      * @param address IP address or hostname of the log server. Can include a port number after a colon,
      *           if port number is not specified, default value will be used.
-     * @param config Configuration paramteter. Valid value are -1 <= config <= 2.
+     * @param config Configuration parameter. Valid value are -1 <= config <= 2.
+     * @param timeout Burst filter timeout parameter.
      * @return caPutJsonLogStatus Status code.
      */
-    caPutJsonLogStatus initialize(const char* address, caPutJsonLogConfig config);
+    caPutJsonLogStatus initialize(const char* address, caPutJsonLogConfig config, double timeout);
 
     /**
      * @brief Add a put details packed as a ::LOGDATA structure to a queue for processing.
@@ -130,9 +134,10 @@ public:
      *
      * @param config New configuration. Valid value are -1 <= config <= 2. Invalid
      * value will default to 1 "caPutJsonLogAll".
+     * @param timeout New burst filter timeout value
      * @return int Status code.
      */
-    caPutJsonLogStatus reconfigure(caPutJsonLogConfig config);
+    caPutJsonLogStatus reconfigure(caPutJsonLogConfig config, double timeout);
 
     /**
      * @brief Print report client logger information to the console.
@@ -142,6 +147,14 @@ public:
      */
     caPutJsonLogStatus report(int level);
 
+    /**
+     * @brief Change the burst filter timeout
+     *
+     * @param timeout Time between puts to the same PV that will be considered a burst
+     * @return int Status code.
+     */
+    caPutJsonLogStatus setBurstTimeout(double timeout);
+
 private:
 
     // Singelton instance of this class.
@@ -149,6 +162,8 @@ private:
 
     // Logger configuration
     int config; // To modify or read this value only epicsAtomic methods should be used
+
+    double burstTimeout;
 
     // Interthread communication
     epicsMessageQueue caPutJsonLogQ;

--- a/caPutLogApp/caPutLog.c
+++ b/caPutLogApp/caPutLog.c
@@ -51,12 +51,12 @@ void caPutLogShow (int level)
 /*
  *  caPutLogReconf()
  */
-int caPutLogReconf (int config)
+int caPutLogReconf (int config, double timeout)
 {
     if (config < 0)
         caPutLogTaskStop();
     else
-        caPutLogTaskStart(config);
+        caPutLogTaskStart(config, timeout);
     caPutLogClientFlush();
     return caPutLogSuccess;
 }
@@ -69,7 +69,7 @@ static void caPutLogExitProc(void *arg)
 /*
  *  caPutLogInit()
  */
-int caPutLogInit (const char *addr_str, int config)
+int caPutLogInit (const char *addr_str, int config, double timeout)
 {
     int status;
 
@@ -96,7 +96,7 @@ int caPutLogInit (const char *addr_str, int config)
         return caPutLogError;
     }
 
-    status = caPutLogTaskStart(config);
+    status = caPutLogTaskStart(config, timeout);
     if (status) {
         return caPutLogError;
     }

--- a/caPutLogApp/caPutLog.h
+++ b/caPutLogApp/caPutLog.h
@@ -17,10 +17,11 @@ extern "C" {
 #define caPutLogAll         1   /* log all puts */
 #define caPutLogAllNoFilter 2   /* log all puts no filtering on same PV*/
 
-epicsShareFunc int caPutLogInit (const char *addr_str, int config);
-epicsShareFunc int caPutLogReconf (int config);
+epicsShareFunc int caPutLogInit (const char *addr_str, int config, double timeout);
+epicsShareFunc int caPutLogReconf (int config, double timeout);
 epicsShareFunc void caPutLogShow (int level);
 epicsShareFunc void caPutLogSetTimeFmt (const char *format);
+epicsShareFunc void caPutLogSetBurstTimeout (double timeout);
 
 #ifdef __cplusplus
 }

--- a/caPutLogApp/caPutLogShellCommands.c
+++ b/caPutLogApp/caPutLogShellCommands.c
@@ -6,24 +6,28 @@
 
 static const iocshArg caPutLogInitArg0 = {"address", iocshArgString};
 static const iocshArg caPutLogInitArg1 = {"config", iocshArgInt};
+static const iocshArg caPutLogInitArg2 = {"burst timeout", iocshArgDouble};
 static const iocshArg *const caPutLogInitArgs[] = {
     &caPutLogInitArg0,
-    &caPutLogInitArg1
+    &caPutLogInitArg1,
+    &caPutLogInitArg2
 };
-static const iocshFuncDef caPutLogInitDef = {"caPutLogInit", 2, caPutLogInitArgs};
+static const iocshFuncDef caPutLogInitDef = {"caPutLogInit", 3, caPutLogInitArgs};
 static void caPutLogInitCall(const iocshArgBuf *args)
 {
-    caPutLogInit(args[0].sval, args[1].ival);
+    caPutLogInit(args[0].sval, args[1].ival, args[2].dval);
 }
 
 static const iocshArg caPutLogReconfArg0 = {"config", iocshArgInt};
+static const iocshArg caPutLogReconfArg1 = {"burst timeout", iocshArgDouble};
 static const iocshArg *const caPutLogReconfArgs[] = {
-    &caPutLogReconfArg0
+    &caPutLogReconfArg0,
+    &caPutLogReconfArg1
 };
-static const iocshFuncDef caPutLogReconfDef = {"caPutLogReconf", 1, caPutLogReconfArgs};
+static const iocshFuncDef caPutLogReconfDef = {"caPutLogReconf", 2, caPutLogReconfArgs};
 static void caPutLogReconfCall(const iocshArgBuf *args)
 {
-    caPutLogReconf(args[0].ival);
+    caPutLogReconf(args[0].ival, args[1].dval);
 }
 
 static const iocshArg caPutLogShowArg0 = {"level", iocshArgInt};
@@ -46,6 +50,16 @@ static void caPutLogSetTimeFmtCall(const iocshArgBuf *args)
     caPutLogSetTimeFmt(args[0].sval);
 }
 
+static const iocshArg caPutLogSetBurstTimeoutArg0 = {"burst timeout", iocshArgDouble};
+static const iocshArg *const caPutLogSetBurstTimeoutArgs[] = {
+    &caPutLogSetBurstTimeoutArg0
+};
+static const iocshFuncDef caPutLogSetBurstTimeoutDef = {"caPutLogSetBurstTimeout", 1, caPutLogSetBurstTimeoutArgs};
+static void caPutLogSetBurstTimeoutCall(const iocshArgBuf *args)
+{
+    caPutLogSetBurstTimeout(args[0].dval);
+}
+
 static void caPutLogRegister(void)
 {
     static int done = FALSE;
@@ -56,5 +70,6 @@ static void caPutLogRegister(void)
     iocshRegister(&caPutLogReconfDef,caPutLogReconfCall);
     iocshRegister(&caPutLogShowDef,caPutLogShowCall);
     iocshRegister(&caPutLogSetTimeFmtDef,caPutLogSetTimeFmtCall);
+    iocshRegister(&caPutLogSetBurstTimeoutDef,caPutLogSetBurstTimeoutCall);
 }
 epicsExportRegistrar(caPutLogRegister);

--- a/caPutLogApp/caPutLogTask.c
+++ b/caPutLogApp/caPutLogTask.c
@@ -108,6 +108,7 @@ static DBADDR *pcaPutLogPV;             /* Pointer to PV address structure,
 static epicsMessageQueueId caPutLogQ;   /* Mailbox for caPutLogTask */
 
 static volatile int caPutLogConfig;
+static volatile double burstTimeout;
 
 int caPutLogDebug = 0;
 epicsExportAddress(int, caPutLogDebug);
@@ -118,7 +119,7 @@ epicsExportAddress(int, caPutLogDebug);
 #define isDbrNumeric(type) ((type) > DBR_STRING && (type) <= DBR_ENUM)
 
 /* Start Rng Log Task */
-int caPutLogTaskStart(int config)
+int caPutLogTaskStart(int config, double timeout)
 {
     epicsThreadId threadId;
     char *caPutLogPVEnv;
@@ -157,6 +158,7 @@ int caPutLogTaskStart(int config)
     }
 
     caPutLogConfig = config;
+    burstTimeout = (timeout > 0.0) ? timeout : DEFAULT_BURST_TIMEOUT;
 
     if (epicsThreadGetId("caPutLog")) {
         if (caPutLogDebug)
@@ -218,11 +220,22 @@ void caPutLogSetTimeFmt (const char *format)
         timeFormat = format;
 }
 
+void caPutLogSetBurstTimeout(double timeout)
+{
+    if (timeout > 0.0) {
+        burstTimeout = timeout;
+    } else {
+        burstTimeout = DEFAULT_BURST_TIMEOUT;
+        errlogSevPrintf(errlogMinor, "caPutLog: invalid timeout value = %f. Setting default value = %f\n", timeout, burstTimeout);
+    }
+}
+
 static void caPutLogTask(void *arg)
 {
     int sent = FALSE, burst = FALSE;
     int config;
     int msg_size;
+    double timeout;
     LOGDATA *pcurrent, *pnext;
     VALUE old_value, max_value, min_value;
     VALUE *pold=&old_value, *pmax=&max_value, *pmin=&min_value;
@@ -248,8 +261,10 @@ static void caPutLogTask(void *arg)
 
     while (caPutLogConfig != caPutLogNone) {                 /* Main Server Loop */
 
+        timeout = burstTimeout;
+
         /* Receive next message */
-        msg_size = epicsMessageQueueReceiveWithTimeout(caPutLogQ, &pnext, MSG_SIZE, 5.0);
+        msg_size = epicsMessageQueueReceiveWithTimeout(caPutLogQ, &pnext, MSG_SIZE, timeout);
         config = caPutLogConfig;
 
         if (msg_size == -1) {   /* timeout */

--- a/caPutLogApp/caPutLogTask.h
+++ b/caPutLogApp/caPutLogTask.h
@@ -18,6 +18,8 @@ extern "C" {
 #define MAX_ARRAY_SIZE_BYTES 0
 #endif
 
+#define DEFAULT_BURST_TIMEOUT 5.0
+
 typedef union {
     epicsInt8       v_int8;
     epicsUInt8      v_uint8;
@@ -66,7 +68,7 @@ typedef struct {
     int new_log_size;
 } LOGDATA;
 
-epicsShareFunc int caPutLogTaskStart(int config);
+epicsShareFunc int caPutLogTaskStart(int config, double timeout);
 epicsShareFunc void caPutLogTaskStop(void);
 epicsShareFunc void caPutLogTaskSend(LOGDATA *plogData);
 epicsShareFunc void caPutLogTaskShow(void);

--- a/test/caPutJsonLogTest.cpp
+++ b/test/caPutJsonLogTest.cpp
@@ -881,7 +881,7 @@ MAIN(caPutJsonLogTests)
     startIoc();
     CaPutJsonLogTask *logger =  CaPutJsonLogTask::getInstance();
     if (logger == NULL) testAbort("Failed to initialize logger.");
-    logger->initialize(logServerAddress.c_str(), caPutJsonLogOnChange);
+    logger->initialize(logServerAddress.c_str(), caPutJsonLogOnChange, 5.0);
     testDiag("Test IOC ready");
     testIocReady.trigger();
 


### PR DESCRIPTION
This PR introduces a way to configure the burst filter timeout in runtime, thus allowing users to match the burst filter to their application needs.

Introduces one new function for each logger implementation:

- `caPutLogSetBurstTimeout(<timeout>)`
- `caPutJsonLogSetBurstTimeout(<timeout>)`

This parameter can also be passed in the initialization or reconfiguration functions:

- `caPutLogInit(<address>[:port], <interest level>, <timeout>)`
- `caPutLogReconf(<interest level>, <timeout>)`
- `caPutJsonLogInit(<address>[:port], <interest level>, <timeout>)`
- `caPutJsonLogReconf(<interest level>, <timeout>)`