### PR TITLE
call yajl_gen_free() to prevent memory leaks

### DIFF
--- a/caPutLogApp/caPutJsonLogTask.cpp
+++ b/caPutLogApp/caPutJsonLogTask.cpp
@@ -377,6 +377,7 @@ void CaPutJsonLogTask::addPutToQueue(LOGDATA * plogData)
     flag = call; \
     if (flag != yajl_gen_status_ok) { \
         errlogSevPrintf(errlogMinor, "caPutJsonLog: JSON generation error\n"); \
+        yajl_gen_free(handle); \
         return caPutJsonLogError; \
     } \
     }
@@ -598,6 +599,7 @@ caPutJsonLogStatus CaPutJsonLogTask::buildJsonMsg(const VALUE *pold_value, const
     /* First log to a PV so we can append new line later for the logging to a server */
     this->logToPV(json);
     this->logToServer(json.append("\n"));
+    yajl_gen_free(handle);
     return caPutJsonLogSuccess;
 }
 


### PR DESCRIPTION
Running `valgrind --leak-check=full --show-leak-kinds=all caPutJsonLogTest` it was observed:
```
==2145056== 29,216 (352 direct, 28,864 indirect) bytes in 11 blocks are definitely lost in loss record 833 of 840
==2145056==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==2145056==    by 0x23A4A2: yajl_buf_alloc (yajl_buf.c:58)
==2145056==    by 0x23A95B: yajl_gen_alloc (yajl_gen.c:123)
==2145056==    by 0x16F977: CaPutJsonLogTask::buildJsonMsg(VALUE const*, LOGDATA const*, bool, VALUE const*, VALUE const*) (caPutJsonLogTask.cpp:399)
==2145056==    by 0x1706B3: CaPutJsonLogTask::caPutJsonLogTask(void*) (caPutJsonLogTask.cpp:301)
==2145056==    by 0x23012C: start_routine (osdThread.c:441)
==2145056==    by 0x4874608: start_thread (pthread_create.c:477)
==2145056==    by 0x4D52132: clone (clone.S:95)

```

After this PR change was applied `valgrind` did not report and more leaks from `CaPutJsonLogTask::buildJsonMsg`.
Tested with epics base 7.0.7.