### PR TITLE
Add metadata information to json output

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,28 +8,49 @@ on:
     branches:
       - '**'
 
+env:
+  SETUP_PATH: .ci
+
 jobs:
   build:
+    name: ${{ matrix.os }}/${{ matrix.base }}/${{ matrix.cmp }}/${{ matrix.configuration }}
+    runs-on: ${{ matrix.os}}
+    env:
+      CMP: ${{ matrix.cmp }}
+      BCFG: ${{ matrix.configuration }}
+      BASE: ${{ matrix.base }}
 
-    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            base: "7.0"
 
     steps:
     - uses: actions/checkout@v3
-    - name: Setup build tools
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install curl make patch m4 build-essential tclx python3-dev git
-    - name: Setup & build EPICS base
-      run: |
-        mkdir epics && cd epics
-        curl https://epics-controls.org/download/base/base-7.0.7.tar.gz | tar xz
-        cd base-7.0.7
-        make
-    - name: Build caPutLog
-      run: |
-        echo "EPICS_BASE=$GITHUB_WORKSPACE/epics/base-7.0.7" >> configure/RELEASE.local
-        make
-    - name: Run tests
-      run:  |
-        cd test/O.linux-x86_64/
-        ./caPutJsonLogTest
+      with:
+        submodules: true
+
+    - name: Prepare and compile EPICS dependencies
+      run: python .ci/cue.py prepare
+
+    - name: Build main module
+      run: python .ci/cue.py build
+
+    - name: Run main module tests
+      run: python .ci/cue.py -T 20M test
+
+    - name: Upload tapfiles Artifact
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: tapfiles ${{ matrix.name }}
+        path: "**/O.*/*.tap"
+        if-no-files-found: ignore
+
+    - name: Collect and show test results
+      if: ${{ always() }}
+      run: python .ci/cue.py -T 5M test-results

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,35 @@
+name: caPutLog CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup build tools
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install curl make patch m4 build-essential tclx python3-dev git
+    - name: Setup & build EPICS base
+      run: |
+        mkdir epics && cd epics
+        curl https://epics-controls.org/download/base/base-7.0.7.tar.gz | tar xz
+        cd base-7.0.7
+        make
+    - name: Build caPutLog
+      run: |
+        echo "EPICS_BASE=$GITHUB_WORKSPACE/epics/base-7.0.7" >> configure/RELEASE.local
+        make
+    - name: Run tests
+      run:  |
+        cd test/O.linux-x86_64/
+        ./caPutJsonLogTest

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -43,6 +43,10 @@ jobs:
             cross: "RTEMS-pc386-qemu@4.10"
             test: NO
 
+          - os: macos-12
+            cmp: clang
+            configuration: default
+
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,12 +13,13 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.os }}/${{ matrix.base }}/${{ matrix.cmp }}/${{ matrix.configuration }}
+    name: ${{ matrix.os }}/${{ matrix.cmp }}/${{ matrix.configuration }}/${{ matrix.cross }}
     runs-on: ${{ matrix.os}}
     env:
       CMP: ${{ matrix.cmp }}
       BCFG: ${{ matrix.configuration }}
-      BASE: ${{ matrix.base }}
+      CI_CROSS_TARGETS: ${{ matrix.cross }}
+      TEST: ${{ matrix.test }}
 
     strategy:
       fail-fast: false
@@ -27,7 +28,20 @@ jobs:
           - os: ubuntu-latest
             cmp: gcc
             configuration: default
-            base: "7.0"
+
+          - os: ubuntu-latest
+            cmp: gcc
+            configuration: static
+
+          - os: windows-2019
+            cmp: vs2019
+            configuration: static
+
+          - os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            cross: "RTEMS-pc386-qemu@4.10"
+            test: NO
 
     steps:
     - uses: actions/checkout@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".ci"]
+	path = .ci
+	url = https://github.com/epics-base/ci-scripts

--- a/caPutLogApp/caPutJsonLogShellCommands.cpp
+++ b/caPutLogApp/caPutJsonLogShellCommands.cpp
@@ -15,6 +15,7 @@
 #include <errlog.h>
 #include <iocsh.h>
 #include <epicsExport.h>
+#include <string>
 
 #include "caPutJsonLogTask.h"
 
@@ -97,6 +98,27 @@ extern "C"
         #endif
     }
 
+    /* Metadata */
+    int caPutJsonLogAddMetadata(char *property, char *value){
+        CaPutJsonLogTask *logger = CaPutJsonLogTask::getInstance();
+        std::string property_str(property);
+        std::string value_str(value);
+        if (logger != NULL) return logger->addMetadata(property_str, value_str);
+        else return -1;
+    }
+    static const iocshArg caPutJsonLogAddMetadataArg0 = {"property", iocshArgString};
+    static const iocshArg caPutJsonLogAddMetadataArg1 = {"value", iocshArgString};
+    static const iocshArg *const caPutJsonLogAddMetadataArgs[] =
+    {
+        &caPutJsonLogAddMetadataArg0,
+        &caPutJsonLogAddMetadataArg1
+    };
+    static const iocshFuncDef caPutJsonLogAddMetadataDef = {"caPutJsonLogAddMetadata", 2, caPutJsonLogAddMetadataArgs};
+    static void caPutJsonLogAddMetadataCall(const iocshArgBuf *args)
+    {
+        caPutJsonLogAddMetadata(args[0].sval, args[1].sval);
+    }
+
     /* Register JSON IOCsh commands */
     static void caPutJsonLogRegister(void)
     {
@@ -108,6 +130,7 @@ extern "C"
             iocshRegister(&caPutJsonLogReconfDef,caPutJsonLogReconfCall);
             iocshRegister(&caPutJsonLogShowDef,caPutJsonLogShowCall);
             iocshRegister(&caPutLogInitDef,caPutLogInitCall);
+            iocshRegister(&caPutJsonLogAddMetadataDef,caPutJsonLogAddMetadataCall);
             caPutLogRegisterDone = 2;
             break;
 

--- a/caPutLogApp/caPutJsonLogTask.cpp
+++ b/caPutLogApp/caPutJsonLogTask.cpp
@@ -13,8 +13,10 @@
 
 // Standard library imports
 #include <algorithm>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <iterator>
 #include <string>
 
 #ifdef _WIN32
@@ -114,6 +116,22 @@ caPutJsonLogStatus CaPutJsonLogTask::report(int level)
         errlogSevPrintf(errlogMinor, "caPutJsonLog: no clients initialised\n");
         return caPutJsonLogError;
     }
+}
+
+caPutJsonLogStatus CaPutJsonLogTask::addMetadata(std::string property, std::string value)
+{
+    std::pair<std::map<std::string, std::string>::iterator, bool> ret;
+    ret = metadata.insert(std::pair<std::string, std::string>(property,value));
+    if ( ret.second == false ) {
+        metadata.erase(property);
+        ret = metadata.insert(std::pair<std::string, std::string>(property,value));
+        if (ret.second == false) {
+            errlogSevPrintf(errlogMinor, "caPutJsonLog: fail to add property %s to json log\n", property.c_str());
+            return caPutJsonLogError;
+        }
+    }
+    errlogSevPrintf(errlogInfo, "caPutJsonLog: add property %s with value %s to json log\n", property.c_str(), value.c_str());
+    return caPutJsonLogSuccess;
 }
 
 caPutJsonLogStatus CaPutJsonLogTask::initialize(const char* addresslist, caPutJsonLogConfig config)
@@ -446,6 +464,17 @@ caPutJsonLogStatus CaPutJsonLogTask::buildJsonMsg(const VALUE *pold_value, const
     CALL_YAJL_FUNCTION_AND_CHECK_STATUS(status, yajl_gen_string(handle,
                             reinterpret_cast<const unsigned char *>(pLogData->userid),
                             strlen(pLogData->userid)));
+
+    // Add metadata
+    std::map<std::string, std::string>::iterator meta_it;
+    for(meta_it = metadata.begin(); meta_it != metadata.end(); meta_it++){
+            CALL_YAJL_FUNCTION_AND_CHECK_STATUS(status, yajl_gen_string(handle,
+                            reinterpret_cast<const unsigned char *>(meta_it->first.c_str()),
+                            meta_it->first.length()));
+            CALL_YAJL_FUNCTION_AND_CHECK_STATUS(status, yajl_gen_string(handle,
+                            reinterpret_cast<const unsigned char *>(meta_it->second.c_str()),
+                            meta_it->second.length()));
+    }
 
     // Add PV name
     const unsigned char str_pvName[] = "pv";

--- a/caPutLogApp/caPutJsonLogTask.cpp
+++ b/caPutLogApp/caPutJsonLogTask.cpp
@@ -134,6 +134,26 @@ caPutJsonLogStatus CaPutJsonLogTask::addMetadata(std::string property, std::stri
     return caPutJsonLogSuccess;
 }
 
+bool CaPutJsonLogTask::isMetadataKey(std::string property)
+{
+    return metadata.count(property) > 0;
+}
+
+void CaPutJsonLogTask::removeAllMetadata()
+{
+    metadata.clear();
+}
+
+size_t CaPutJsonLogTask::metadataCount()
+{
+    return metadata.size();
+}
+
+std::map<std::string, std::string> CaPutJsonLogTask::getMetadata()
+{
+    return metadata;
+}
+
 caPutJsonLogStatus CaPutJsonLogTask::initialize(const char* addresslist, caPutJsonLogConfig config)
 {
     caPutJsonLogStatus status;

--- a/caPutLogApp/caPutJsonLogTask.h
+++ b/caPutLogApp/caPutJsonLogTask.h
@@ -21,6 +21,7 @@
 #include <logClient.h>
 #include <epicsMessageQueue.h>
 #include <dbAddr.h>
+#include <map>
 #include <epicsThread.h>
 
 // Includes from this module
@@ -142,6 +143,14 @@ public:
      */
     caPutJsonLogStatus report(int level);
 
+    /**
+     * @brief Add IOC metadata to json output
+     *
+     * @param property JSON property
+     * @param value Value associated with property
+     */
+    caPutJsonLogStatus addMetadata(std::string property, std::string value);
+
 private:
 
     // Singleton instance of this class.
@@ -171,6 +180,9 @@ private:
 
     // Total count of logged puts
     int caPutTotalCount; // To modify or read this value only epicsAtomic methods should be used
+
+    // IOC metadata
+    std::map<std::string, std::string> metadata;
 
     // Class methods (Do not allow public constructors - class is designed as singleton)
     CaPutJsonLogTask();

--- a/caPutLogApp/caPutJsonLogTask.h
+++ b/caPutLogApp/caPutJsonLogTask.h
@@ -151,6 +151,33 @@ public:
      */
     caPutJsonLogStatus addMetadata(std::string property, std::string value);
 
+    /**
+     * @brief Check if a property is a key in the metadata map
+     *
+     * @param property JSON property
+     * @return bool Status.
+     */
+    bool isMetadataKey(std::string property);
+
+    /**
+     * @brief Clears the metadata map
+     */
+    void removeAllMetadata();
+
+    /**
+     * @brief Gets the number of elements in the metadata map
+     *
+     * @return size_t Number of elements in metadata
+     */
+    size_t metadataCount();
+
+    /**
+     * @brief Gets the metadata list object
+     *
+     * @return map<string, string> the Metadata map
+     */
+    std::map<std::string, std::string> getMetadata();
+
 private:
 
     // Singleton instance of this class.

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,6 +8,7 @@ include $(TOP)/configure/CONFIG
 DBDDEPENDS_FILES += dbTestIoc.dbd$(DEP)
 TARGETS += $(COMMON_DIR)/dbTestIoc.dbd
 dbTestIoc_DBD += base.dbd
+CXXFLAGS=-std=c++11
 
 # Libraries to which the test executable is linked
 PROD_LIBS = caPutLog

--- a/test/caPutJsonLogTest.cpp
+++ b/test/caPutJsonLogTest.cpp
@@ -23,6 +23,7 @@
 #include <osiSock.h>
 #include <envDefs.h>
 #include <errlog.h>
+#include <epicsString.h>
 #include <db_access.h>
 #include <db_access_routines.h>
 #include <dbUnitTest.h>
@@ -480,7 +481,9 @@ void commonTests(JsonParser &jsonParser, const char* pvname, const char * testPr
     // Test hostname
     char hostname[1024];
     gethostname(hostname, 1024);
-    testOk(!jsonParser.host.compare(hostname),
+
+    // asLibRoutines changes the hostnames to lower-case; some OSs are not so kind.
+    testOk(!epicsStrCaseCmp(hostname, jsonParser.host.c_str()),
             "%s - %s", testPrefix, "Hostname check");
 
     // Test username


### PR DESCRIPTION
The iocLogPrefix solution creates string that is a mixed between plain text and json. That is harder to parse and search than having only json.
This patch adds the caPutJsonLogMetadata command as an option to have metadata in json format to logs.

This is relevant for large facilities that need to filter/analyze collected information from many systems.