### PR TITLE
Patch issues with pvmonitors in EPICS base

### DIFF
--- a/caPutLogApp/caPutLogAs.c
+++ b/caPutLogApp/caPutLogAs.c
@@ -124,6 +124,13 @@ static void caPutLogAs(asTrapWriteMessage *pmessage, int afterPut)
     LOGDATA *plogData;
     long options, num_elm;
     long status;
+    /*
+     * tmp_addr is used so that we don't overwrite the original pchan when we
+     * call get_array_info from caPutLogActualArraySize.
+     */
+    dbAddr tmp_addr;
+
+    memcpy(&tmp_addr, paddr, sizeof(dbAddr));
 
     if (!afterPut) {                    /* before put */
         plogData = caPutLogDataCalloc();
@@ -155,7 +162,7 @@ static void caPutLogAs(asTrapWriteMessage *pmessage, int afterPut)
         status = dbGetField(
             paddr, plogData->type, &plogData->old_value, &options, &num_elm, 0);
         plogData->old_log_size = num_elm;
-        plogData->old_size = caPutLogActualArraySize(paddr);
+        plogData->old_size = caPutLogActualArraySize(&tmp_addr);
         plogData->is_array = paddr->no_elements > 1 ? TRUE : FALSE;
 
         if (status) {
@@ -174,7 +181,7 @@ static void caPutLogAs(asTrapWriteMessage *pmessage, int afterPut)
         status = dbGetField(
             paddr, plogData->type, &plogData->new_value, &options, &num_elm, 0);
         plogData->new_log_size = num_elm;
-        plogData->new_size = caPutLogActualArraySize(paddr);
+        plogData->new_size = caPutLogActualArraySize(&tmp_addr);
         plogData->is_array = plogData->is_array || paddr->no_elements > 1 ? TRUE : FALSE;
 
         if (status) {

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -8,6 +8,11 @@ R4-1: Changes since R4-0
 
 * Prevent crashes by only allowing one set of commands to be registered.
 
+* Fix an issue where waveform-type arrays would not send out monitors in certain
+  cases. See https://epics.anl.gov/tech-talk/2024/msg00481.php and 
+  https://github.com/epics-base/pva2pva/issues/60 for examples.
+
+
 R4-0: Changes since R3-7
 ------------------------
 


### PR DESCRIPTION
If you have a waveform-type array (aai, waveform, etc.) and have caputlog loaded and initialised, then the IOC will no longer send out pvmonitors on changes (though it still sends on CA monitors). This seems to be due to a bug in PVAccessCPP about caching of PV channels: when we hit the caPutLog callback code on a put, we call get_array_info from the record rset code, which overwrites the requested field with the internal array buffer. This means that we modify the original pchan in memory which later causes a field comparison in the db event code (db_post_events) to fail.

This patch is a minimal fix to caPutLog to get rid of the problem. While the actual issue seems to be a PVAccessCPP one (it seems that the latest version of PVXS does not have this problem), it seems simpler to fix it here instead of digging deeply into code that ultimately will be no longer in use in a few years.