### PR TITLE
Fix JSON logger reporting duplicate values despite configuration

### DIFF
--- a/caPutLogApp/caPutJsonLogTask.cpp
+++ b/caPutLogApp/caPutJsonLogTask.cpp
@@ -441,6 +441,17 @@ caPutJsonLogStatus CaPutJsonLogTask::buildJsonMsg(const VALUE *pold_value, const
     unsigned char interBuffer[interBufferSize];
     yajl_gen_status status;
 
+    // Dont log if logging is disabled
+    if (this->config == caPutJsonLogNone) {
+        return caPutJsonLogSuccess;
+    }
+
+    // Dont log duplicate values if configured so
+    if (this->config == caPutJsonLogOnChange && !burst) {
+        if (this->compareValue(&pLogData->old_value, &pLogData->new_value.value, pLogData->type))
+            return caPutJsonLogSuccess;
+    }
+
     // Configure yajl generator
     yajl_gen handle = yajl_gen_alloc(NULL);
     if (handle == NULL) {

--- a/caPutLogApp/caPutJsonLogTask.cpp
+++ b/caPutLogApp/caPutJsonLogTask.cpp
@@ -441,11 +441,6 @@ caPutJsonLogStatus CaPutJsonLogTask::buildJsonMsg(const VALUE *pold_value, const
     unsigned char interBuffer[interBufferSize];
     yajl_gen_status status;
 
-    // Dont log if logging is disabled
-    if (this->config == caPutJsonLogNone) {
-        return caPutJsonLogSuccess;
-    }
-
     // Dont log duplicate values if configured so
     if (this->config == caPutJsonLogOnChange && !burst) {
         if (this->compareValue(&pLogData->old_value, &pLogData->new_value.value, pLogData->type))

--- a/caPutLogApp/caPutJsonLogTask.h
+++ b/caPutLogApp/caPutJsonLogTask.h
@@ -282,15 +282,13 @@ private:
     void calculateMax(VALUE *pres, const VALUE *pa, const VALUE *pb, short type);
 
     /**
-     * @brief Compare values in two ::VALUE structures if they are the same.
+     * @brief Compare values in a LOGDATA structure and see if they are the same
      *
-     * @param pa First ::VALUE structure to be compared.
-     * @param pb Second ::VALUE structure to be compared.
-     * @param type EPICS DRB_* type stored in the input structures.
+     * @param pLogData Pointer to log data containing values to compare
      * @return true If values are the same.
      * @return false  If values are not the same.
      */
-    bool compareValue(const VALUE *pa, const VALUE *pb, short type);
+    bool compareValues(const LOGDATA *pLogData);
 
     /**
      * @brief Get a string representation of the value stored in the ::VALUE.


### PR DESCRIPTION
This is (roughly) a cherry-pick of https://github.com/epics-modules/caPutLog/pull/5/commits/ce7bd90fe57ecb381e85731d4ddd16a2c4809beb.

Fixes #30 