### PR TITLE
Fix the issue that the log does not stop when config=-1.

### DIFF
--- a/caPutLogApp/caPutJsonLogTask.cpp
+++ b/caPutLogApp/caPutJsonLogTask.cpp
@@ -346,6 +346,11 @@ void CaPutJsonLogTask::caPutJsonLogTask(void *arg)
         // Receive new put with timeout
         msgSize = this->caPutJsonLogQ.receive(&pnext, sizeof(LOGDATA *), this->burstTimeout);
 
+        // Do not log if configured as caPutJsonLogNone
+	if (epics::atomic::get(this->config) == caPutJsonLogNone){
+	    continue;
+	}
+
         /* Timeout */
         if (msgSize == -1) {
             // If we have have unsent message and timeout occurred, send the cached change


### PR DESCRIPTION
I added an if structure in the worker loop and it checks the config. If config=-1, continue the loop without creating a log.
This fix is tested.