### PR TITLE
Fix max. hostname length

### DIFF
--- a/caPutLogApp/caPutLogTask.h
+++ b/caPutLogApp/caPutLogTask.h
@@ -10,7 +10,7 @@ extern "C" {
 #endif
 
 #define MAX_USERID_SIZE 32
-#define MAX_HOSTID_SIZE 32
+#define MAX_HOSTID_SIZE 256
 
 #if JSON_AND_ARRAYS_SUPPORTED
 #define MAX_ARRAY_SIZE_BYTES 400


### PR DESCRIPTION
Was causing tests to fail on CI machines (GHA) that used long hostnames.

(See runs on https://github.com/epics-modules/caPutLog/pull/39)
